### PR TITLE
SMP enable by default

### DIFF
--- a/priv/leo_storage.conf
+++ b/priv/leo_storage.conf
@@ -170,7 +170,7 @@ leo_object_storage.metadata_storage = leveldb
 ## --------------------------------------------------------------------
 ## RPC-Server's acceptors
 ## this value must be determinted by following logic
-## rpc.server.acceptor need to be larger than 
+## rpc.server.acceptor need to be larger than
 ## rpc.client.connection_pool(buffer)_size * "# of storage nodes + # of manager nodes in your cluster"
 ## The default value is suitable for less than 16 nodes in a cluster
 ## rpc.server.acceptors = 128
@@ -252,6 +252,9 @@ erlang.crash_dump = ./log/erl_crash.dump
 
 ## Raise the ETS table limit
 erlang.max_ets_tables = 256000
+
+## Enable SMP
+erlang.smp = enable
 
 ## Raise the default erlang process limit
 process_limit = 1048576

--- a/priv/leo_storage.schema
+++ b/priv/leo_storage.schema
@@ -860,6 +860,14 @@
   {default, "256000"}
  ]}.
 
+%% @doc Enable or disable SMP
+{mapping,
+ "erlang.smp",
+ "vm_args.-smp",
+ [
+  {default, "enable"}
+ ]}.
+
 %% %% @doc Raise the ETS table limit
 %% {mapping,
 %%  "erlang.hidden_flag",


### PR DESCRIPTION
I testing LeoFS on virtual machine with one cpu core and have error:

```
enif_send: env==NULL on non-SMP VM[os_mon] memory supervisor port (memsup): Erlang has closed
```

Maybe default set smp is enable?
